### PR TITLE
Add Piano Genie credits and license.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,15 @@
-Copyright (c) <year> <copyright-holders>
+Copyright 2023 IMAGINARY gGmbH. All Rights Reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright 2018 Google Inc. All Rights Reserved.
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Typescript library with demo app
+# muski-synth-genie
+
+Drawing-baseed synth powered by Magenta's Piano Genie model for the MusKI website.
 
 ## Installation
 
@@ -52,10 +54,17 @@ SCSS and Typescript.
 
 ## Credits
 
-Developed by <author-name> for <company-name>.
+Based on Piano Genie, created by Chris Donahue, Ian Simon, Sander Dieleman and part of the 
+[Google Magenta project](https://magenta.tensorflow.org/).
+
+Developed by Christian Stussak for IMAGINARY gGmbH.
 
 ## License
 
-Copyright © <year> <copyright-holder>
+Piano Genie:
+Copyright 2018 Google Inc. All Rights Reserved.
 
-Licensed under the MIT license (see the [`LICENSE`](LICENSE) file).
+Modifications:
+Copyright 2023 IMAGINARY gGmbH.
+
+Licensed under the Apache License (see LICENSE).


### PR DESCRIPTION
We need to add credit Piano Genie and add the license for Muski's launch. I changed the license to Apache to match Piano Genie's.